### PR TITLE
fix(image): FlashList images showing previous image during recycling

### DIFF
--- a/src/features/orders/components/OrderListItem.tsx
+++ b/src/features/orders/components/OrderListItem.tsx
@@ -32,7 +32,11 @@ export const OrderListItem = ({ order }: Props) => {
       onPress={() => navigation.navigate('OrderDetails', { orderId: order.id })}
     >
       <Box flexDirection="row" alignItems="flex-start" g="m" p="m">
-        <Image source={firstLineItem?.image?.url} style={styles.image} />
+        <Image
+          source={firstLineItem?.image?.url}
+          recyclingKey={firstLineItem?.image?.url}
+          style={styles.image}
+        />
 
         <Box flex={1} g="s">
           <Text variant="h3">Order {order.name}</Text>

--- a/src/features/products/components/ProductList/ProductListItem.tsx
+++ b/src/features/products/components/ProductList/ProductListItem.tsx
@@ -59,7 +59,11 @@ export const ProductListItem = memo(
     return (
       <PressableOpacity onPress={onItemPress} style={style}>
         <View style={styles.imageContainer}>
-          <Image source={product.featuredImage?.url} style={styles.image} />
+          <Image
+            source={product.featuredImage?.url}
+            recyclingKey={product.featuredImage?.url}
+            style={styles.image}
+          />
         </View>
 
         <Text>{product.title}</Text>


### PR DESCRIPTION
Fixes https://github.com/mk-nickyang/a-pawfect-place-app/issues/4

Added `recyclingKey` for image components in FlashList

> Changing this prop resets the image view content to blank or a placeholder before loading and rendering the final image. This is especially useful for any kinds of recycling views like [FlashList](https://github.com/shopify/flash-list) to prevent showing the previous source before the new one fully loads.

See https://docs.expo.dev/versions/latest/sdk/image/#recyclingkey